### PR TITLE
🤰🏿 Normalize longitude to range [-180, 180] (closes #28)

### DIFF
--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -18,6 +18,22 @@ import Map from './Map'
  */
 const VISIBLE_CLUSTER_ZOOM_LIMIT = 12
 
+/**
+ * Normalize longitude to range [-180, 180].
+ *
+ * @param {number} longitude Longitude in degrees.
+ * @returns Longitude in degrees in the range [-180, 180].
+ */
+const normalizeLongitude = (longitude) => {
+  while (longitude < -180) {
+    longitude += 360
+  }
+  while (longitude > 180) {
+    longitude -= 360
+  }
+  return longitude
+}
+
 const MapPage = () => {
   const history = useHistory()
   const container = useRef(null)
@@ -57,9 +73,9 @@ const MapPage = () => {
 
         const query = {
           nelat: bounds.ne.lat,
-          nelng: bounds.ne.lng,
+          nelng: normalizeLongitude(bounds.ne.lng),
           swlat: bounds.sw.lat,
-          swlng: bounds.sw.lng,
+          swlng: normalizeLongitude(bounds.sw.lng),
           muni: filters.muni ? 1 : 0,
           t: filters.types.toString(),
         }


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

:rocket: Ready

## Description

Normalizes the longitude of the map bounds to the range [-180, 180] for compatibility with the Falling Fruit API.

Fixes #28 

## Todos

The general help function `normalizeLongitude` may be best moved to a new or existing module under `/utils`. I will leave that decision to you, as I don't have a good sense of how the code is meant to be organized.

