### PR TITLE
🦾 Font scaling and other touch-ups

### DIFF
--- a/src/components/desktop/MainPane.js
+++ b/src/components/desktop/MainPane.js
@@ -13,8 +13,6 @@ const Container = styled.div`
 `
 
 const StyledButton = styled(Button)`
-  background-color: ${({ theme }) => theme.background};
-  color: ${({ theme }) => theme.orange};
   margin: 10px 10px;
   padding: 15px 0;
   // TODO: Siraj add box shadow and extra white border. What's the best way to add another white border? ("raised" prop)
@@ -36,6 +34,7 @@ const MainPane = () => {
       <Search />
       <PagedList />
       <StyledButton
+        secondary
         onClick={() =>
           history.push({
             pathname: '/map/entry/new',

--- a/src/components/entry/Entry.js
+++ b/src/components/entry/Entry.js
@@ -29,7 +29,7 @@ export const TextContent = styled.article`
   }
   h2 {
     margin-top: 0;
-    font-size: 18px;
+    font-size: 1.125rem;
   }
 
   box-sizing: border-box;

--- a/src/components/entry/Entry.js
+++ b/src/components/entry/Entry.js
@@ -29,7 +29,7 @@ export const TextContent = styled.article`
   }
   h2 {
     margin-top: 0;
-    font-size: 1.125rem;
+    font-size: 1rem;
   }
 
   box-sizing: border-box;

--- a/src/components/entry/Entry.js
+++ b/src/components/entry/Entry.js
@@ -5,7 +5,7 @@ import styled from 'styled-components/macro'
 import { useSearch } from '../../contexts/SearchContext'
 import { getLocationById, getReviews } from '../../utils/api'
 import { EntryTabs, Tab, TabList, TabPanel, TabPanels } from '../ui/EntryTabs'
-import LoadingIndicator from '../ui/LoadingIndicator'
+import LoadingIndicator, { LoadingOverlay } from '../ui/LoadingIndicator'
 import EntryOverview from './EntryOverview'
 import EntryReviews from './EntryReviews'
 import PhotoGrid from './PhotoGrid'
@@ -43,11 +43,12 @@ const Entry = ({ isInDrawer }) => {
   const { typesById } = useSearch()
   const [locationData, setLocationData] = useState()
   const [reviews, setReviews] = useState()
+  const [isLoading, setIsLoading] = useState(true)
   const { id } = useParams()
 
   useEffect(() => {
     async function fetchEntryData() {
-      setLocationData(null)
+      setIsLoading(true)
 
       const [locationData, reviews] = await Promise.all([
         getLocationById(id),
@@ -56,6 +57,8 @@ const Entry = ({ isInDrawer }) => {
 
       setLocationData(locationData)
       setReviews(reviews)
+
+      setIsLoading(false)
     }
 
     if (typesById) {
@@ -63,13 +66,14 @@ const Entry = ({ isInDrawer }) => {
     }
   }, [id, typesById])
 
-  let content
-  if (!locationData || !reviews) {
-    content = <LoadingIndicator vertical cover />
-  } else {
-    const entryOverview = <EntryOverview locationData={locationData} />
-    const entryReviews = <EntryReviews reviews={reviews} />
+  const entryOverview = <EntryOverview locationData={locationData} />
+  const entryReviews = <EntryReviews reviews={reviews} />
 
+  let content
+
+  if (!locationData || !reviews) {
+    content = <LoadingIndicator cover vertical />
+  } else {
     content = (
       <>
         <PhotoGrid
@@ -99,7 +103,11 @@ const Entry = ({ isInDrawer }) => {
     )
   }
 
-  return <Page isInDrawer={isInDrawer}>{content}</Page>
+  return (
+    <Page isInDrawer={isInDrawer}>
+      {content} {isLoading && <LoadingOverlay />}
+    </Page>
+  )
 }
 
 export default Entry

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -51,6 +51,10 @@ const LocationText = styled(ResetButton)`
 
 // Wraps description, last updated text, and review and report buttons
 const Description = styled.section`
+  p {
+    font-size: 1rem;
+  }
+
   & > *:not(:first-child) {
     margin-top: 14px;
   }
@@ -63,6 +67,7 @@ const Description = styled.section`
   & > .updatedTime {
     display: block;
     font-style: italic;
+    font-size: 1rem;
     color: ${({ theme }) => theme.text};
   }
 

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -37,13 +37,13 @@ const IconBesideText = styled.div`
 
   p {
     margin: 0 0 0 4px;
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 `
 const LocationText = styled(ResetButton)`
   font-weight: bold;
   text-align: left;
-  font-size: 14px;
+  font-size: 0.875rem;
   margin: 0 0 0 4px;
   flex: 1;
   color: ${({ theme }) => theme.secondaryText};

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -12,7 +12,7 @@ import { getZoomedInView } from '../../utils/viewportBounds'
 import { ReportModal } from '../form/ReportModal'
 import Button from '../ui/Button'
 import { theme } from '../ui/GlobalStyle'
-import LoadingIndicator from '../ui/LoadingIndicator'
+import { LoadingOverlay } from '../ui/LoadingIndicator'
 import ResetButton from '../ui/ResetButton'
 import { Tag, TagList } from '../ui/Tag'
 import { TextContent } from './Entry'
@@ -118,67 +118,60 @@ const EntryOverview = ({ locationData, className }) => {
 
   return (
     <div className={className}>
-      {/* TODO: Properly center this loading indicator! */}
+      <>
+        {isReportModalOpen && (
+          <ReportModal
+            locationId={locationData.id}
+            name={allTypeNames}
+            onDismiss={() => setIsReportModalOpen(false)}
+          />
+        )}
+        <TextContent>
+          {tagList}
+          <TypesHeader
+            typesData={locationData.type_ids.map((typeId) => typesById[typeId])}
+          />
+          <Description>
+            <p>{locationData.description}</p>
 
-      {locationData ? (
-        <>
-          {isReportModalOpen && (
-            <ReportModal
-              locationId={locationData.id}
-              name={allTypeNames}
-              onDismiss={() => setIsReportModalOpen(false)}
-            />
-          )}
-          <TextContent>
-            {tagList}
-            <TypesHeader
-              typesData={locationData.type_ids.map(
-                (typeId) => typesById[typeId],
-              )}
-            />
-            <Description>
-              <p>{locationData.description}</p>
-
-              <IconBesideText bold onClick={handleAddressClick} tabIndex={0}>
-                <Map color={theme.secondaryText} size={20} />
-                <LocationText>{address}</LocationText>
+            <IconBesideText bold onClick={handleAddressClick} tabIndex={0}>
+              <Map color={theme.secondaryText} size={20} />
+              <LocationText>{address}</LocationText>
+            </IconBesideText>
+            {hasSeasonality(locationData) && (
+              <IconBesideText>
+                <Calendar color={theme.secondaryText} size={20} />
+                <p>
+                  {formatSeasonality(
+                    locationData.season_start,
+                    locationData.season_stop,
+                    locationData.no_season,
+                  )}
+                </p>
               </IconBesideText>
-              {hasSeasonality(locationData) && (
-                <IconBesideText>
-                  <Calendar color={theme.secondaryText} size={20} />
-                  <p>
-                    {formatSeasonality(
-                      locationData.season_start,
-                      locationData.season_stop,
-                      locationData.no_season,
-                    )}
-                  </p>
-                </IconBesideText>
-              )}
+            )}
 
-              <p className="updatedTime">
-                {t('Last Updated')}{' '}
-                <time dateTime={locationData.updated_at}>
-                  {formatISOString(locationData.updated_at)}
-                </time>
-              </p>
+            <p className="updatedTime">
+              {t('Last Updated')}{' '}
+              <time dateTime={locationData.updated_at}>
+                {formatISOString(locationData.updated_at)}
+              </time>
+            </p>
 
-              <div>
-                <Button leftIcon={<Star />}>Review</Button>
-                <Button
-                  leftIcon={<Flag />}
-                  secondary
-                  onClick={() => setIsReportModalOpen(true)}
-                >
-                  Report
-                </Button>
-              </div>
-            </Description>
-          </TextContent>
-        </>
-      ) : (
-        <LoadingIndicator vertical cover />
-      )}
+            <div>
+              <Button leftIcon={<Star />}>Review</Button>
+              <Button
+                leftIcon={<Flag />}
+                secondary
+                onClick={() => setIsReportModalOpen(true)}
+              >
+                Report
+              </Button>
+            </div>
+          </Description>
+        </TextContent>
+      </>
+      {!locationData && <LoadingOverlay />}
     </div>
   )
 }

--- a/src/components/entry/PhotoGrid.js
+++ b/src/components/entry/PhotoGrid.js
@@ -115,10 +115,10 @@ const ExtraImagesWrapper = styled(ResetButton)`
     align-items: center;
 
     font-weight: bold;
-    font-size: 13px;
+    font-size: 0.8125rem;
 
     & > span {
-      font-size: 24px;
+      font-size: 1.5rem;
     }
   }
 `

--- a/src/components/entry/Review.js
+++ b/src/components/entry/Review.js
@@ -8,7 +8,7 @@ const ReviewContainer = styled.div`
   margin-bottom: 20px;
 `
 const Label = styled.p`
-  font-size: 12px;
+  font-size: 0.75rem;
   color: ${({ theme }) => theme.tertiaryText};
   margin: 3px 0px;
 `
@@ -26,13 +26,13 @@ const RatingTable = styled.table`
 const ReviewDescription = styled.section`
   margin-bottom: 8px;
   blockquote {
-    font-size: 16px;
+    font-size: 1rem;
     color: ${({ theme }) => theme.secondaryText};
     margin: 0 0 4px 0;
   }
   cite {
     font-style: italic;
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 `
 const StyledImagePreview = styled(ImagePreview)`

--- a/src/components/filter/CheckboxFilters.js
+++ b/src/components/filter/CheckboxFilters.js
@@ -17,7 +17,7 @@ const StyledLabel = styled.label`
   cursor: pointer;
   display: flex;
   align-items: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: bold;
   color: ${({ theme }) => theme.secondaryText};
 

--- a/src/components/filter/Filter.js
+++ b/src/components/filter/Filter.js
@@ -18,7 +18,8 @@ const StyledFilter = styled.div`
   @media ${({ theme }) => theme.device.desktop} {
     position: absolute;
     width: 100%;
-    z-index: 1;
+    // TODO: order z-indexes in enum
+    z-index: 99;
     background-color: ${({ theme }) => theme.background};
 
     box-shadow: 0 3px 5px ${({ theme }) => theme.shadow};

--- a/src/components/filter/Filter.js
+++ b/src/components/filter/Filter.js
@@ -33,7 +33,7 @@ const StyledFilter = styled.div`
   }
 
   .edible-type-text {
-    font-size: 14px;
+    font-size: 0.875rem;
     font-weight: bold;
     color: ${({ theme }) => theme.secondaryText};
     margin-top: 18px;

--- a/src/components/filter/TreeSelect.js
+++ b/src/components/filter/TreeSelect.js
@@ -109,6 +109,7 @@ const TreeSelectContainer = styled.div`
   label {
     display: flex;
     align-items: center;
+    font-size: 0.875rem;
   }
 
   .checkbox-item {
@@ -125,8 +126,8 @@ const TreeSelectContainer = styled.div`
     content: '';
     background: ${({ theme }) => theme.transparentOrange};
     display: flex;
-    width: 15px;
-    height: 15px;
+    width: 12px;
+    height: 12px;
   }
 
   .checkbox-item:checked:before {

--- a/src/components/filter/TreeSelect.js
+++ b/src/components/filter/TreeSelect.js
@@ -110,6 +110,10 @@ const TreeSelectContainer = styled.div`
     display: flex;
     align-items: center;
     font-size: 0.875rem;
+
+    span {
+      margin-left: 0.25rem;
+    }
   }
 
   .checkbox-item {

--- a/src/components/filter/TreeSelect.js
+++ b/src/components/filter/TreeSelect.js
@@ -47,7 +47,7 @@ const TreeSelectContainer = styled.div`
       color: ${({ theme }) => theme.orange};
       border-radius: 20px;
       padding: 0px 10px 0px 10px;
-      font-size: 12px;
+      font-size: 0.75rem;
 
       .tag-remove {
         display: none;

--- a/src/components/list/EntryList.js
+++ b/src/components/list/EntryList.js
@@ -17,8 +17,10 @@ const convertMetersToMiles = (meters) => (meters * 0.000621371192).toFixed(2)
 const StyledListEntry = styled(ListEntry)`
   cursor: pointer;
 
-  :hover {
-    background-color: ${({ theme }) => darken(0.05, theme.background)};
+  @media ${({ theme }) => theme.device.desktop} {
+    :hover {
+      background-color: ${({ theme }) => darken(0.05, theme.background)};
+    }
   }
 `
 

--- a/src/components/list/EntryList.js
+++ b/src/components/list/EntryList.js
@@ -1,4 +1,5 @@
 import { ChevronRight } from '@styled-icons/boxicons-solid'
+import { darken } from 'polished'
 import { forwardRef } from 'react'
 import { FixedSizeList } from 'react-window'
 import styled from 'styled-components/macro'
@@ -15,13 +16,17 @@ const convertMetersToMiles = (meters) => (meters * 0.000621371192).toFixed(2)
 
 const StyledListEntry = styled(ListEntry)`
   cursor: pointer;
+
+  :hover {
+    background-color: ${({ theme }) => darken(0.05, theme.background)};
+  }
 `
 
 const ScientificName = styled.span`
   margin-left: 2px;
   font-weight: normal;
   font-style: italic;
-  color: ${({ theme }) => theme.secondaryText};
+  color: ${({ theme }) => theme.secondaryBackground};
 `
 
 const EntryList = forwardRef(

--- a/src/components/list/EntryList.js
+++ b/src/components/list/EntryList.js
@@ -28,7 +28,7 @@ const ScientificName = styled.span`
   margin-left: 2px;
   font-weight: normal;
   font-style: italic;
-  color: ${({ theme }) => theme.secondaryBackground};
+  color: ${({ theme }) => theme.secondaryText};
 `
 
 const EntryList = forwardRef(

--- a/src/components/list/PagedList.js
+++ b/src/components/list/PagedList.js
@@ -31,8 +31,6 @@ const ListContainer = styled.div`
   > div:first-child {
     width: 100%;
     height: 100%;
-
-    ${({ $disabled }) => $disabled && 'opacity: 0.4;'}
   }
 `
 
@@ -127,7 +125,7 @@ const PagedList = () => {
     <Rect>
       {({ rect, ref }) => (
         <Container>
-          <ListContainer ref={ref} $disabled={loadingNextPage}>
+          <ListContainer ref={ref}>
             <div>
               {locations.length > 0 ? (
                 <EntryList

--- a/src/components/map/Cluster.js
+++ b/src/components/map/Cluster.js
@@ -27,6 +27,7 @@ const ClusterContainer = styled(ResetButton)`
   background: ${({ theme }) => theme.blue};
   box-shadow: 0 0 4px 1px ${({ theme }) => theme.shadow};
   transform: translate(-50%, -50%);
+  line-height: 0;
 
   &:focus {
     outline: none;

--- a/src/components/map/Location.js
+++ b/src/components/map/Location.js
@@ -40,7 +40,7 @@ const LocationButton = styled(ResetButton)`
 `
 
 const Label = styled.div`
-  font-size: 14px;
+  font-size: 0.875rem;
   color: ${({ theme }) => theme.headerText};
   text-shadow: 0px 0px 4px rgba(0, 0, 0, 0.45);
   margin-top: -5px;

--- a/src/components/map/Location.js
+++ b/src/components/map/Location.js
@@ -42,7 +42,6 @@ const LocationButton = styled(ResetButton)`
 const Label = styled.div`
   font-size: 0.875rem;
   color: ${({ theme }) => theme.headerText};
-  /* text-shadow: 0px 0px 4px rgba(0, 0, 0, 0.45); */
   margin-top: -5px;
   /* Centers labels under each location */
   position: absolute;

--- a/src/components/map/Location.js
+++ b/src/components/map/Location.js
@@ -42,7 +42,7 @@ const LocationButton = styled(ResetButton)`
 const Label = styled.div`
   font-size: 0.875rem;
   color: ${({ theme }) => theme.headerText};
-  text-shadow: 0px 0px 4px rgba(0, 0, 0, 0.45);
+  /* text-shadow: 0px 0px 4px rgba(0, 0, 0, 0.45); */
   margin-top: -5px;
   /* Centers labels under each location */
   position: absolute;
@@ -53,6 +53,11 @@ const Label = styled.div`
   /* Prevents line breaks */
   white-space: nowrap;
   z-index: 1;
+
+  text-shadow: -1px -1px 0 ${({ theme }) => theme.background},
+    1px -1px 0 ${({ theme }) => theme.background},
+    -1px 1px 0 ${({ theme }) => theme.background},
+    1px 1px 0 ${({ theme }) => theme.background};
 `
 
 const Location = memo(({ label, selected, ...props }) => (

--- a/src/components/map/Location.js
+++ b/src/components/map/Location.js
@@ -1,5 +1,4 @@
 import { Map } from '@styled-icons/boxicons-solid'
-import { transparentize } from 'polished'
 import PropTypes from 'prop-types'
 import { memo } from 'react'
 import styled from 'styled-components/macro'
@@ -29,9 +28,10 @@ const LocationButton = styled(ResetButton)`
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background: ${({ theme }) => transparentize(0.25, theme.blue)};
+  background-color: ${({ theme }) => theme.blue};
   transform: translate(-50%, -50%);
-  box-shadow: 0 0 4px 1px rgba(0, 0, 0, 0.12);
+
+  border: 2px solid ${({ theme }) => theme.background};
   z-index: 2;
 
   &:focus {

--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -39,7 +39,7 @@ const Page = styled.div`
 
   > h3 {
     font-weight: normal;
-    font-size: 16px;
+    font-size: 1rem;
     color: ${({ theme }) => theme.tertiaryText};
     margin: 24px 0;
   }

--- a/src/components/ui/BackButton.js
+++ b/src/components/ui/BackButton.js
@@ -10,7 +10,7 @@ const BackButton = styled(ResetButton).attrs((props) => ({
   display: flex;
   align-items: center;
   color: ${({ theme }) => theme.secondaryText};
-  font-size: 15px;
+  font-size: 0.9375rem;
   font-weight: bold;
 `
 

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -1,3 +1,4 @@
+import { darken } from 'polished'
 import styled from 'styled-components/macro'
 
 import { prepend } from './GlobalStyle'
@@ -20,6 +21,14 @@ const StyledButton = styled(ResetButton)`
   border-radius: 100px;
   padding: 0 24px;
   // TODO: make raised and add a location button in main pane
+
+  :hover {
+    background: ${({ $secondary, theme }) =>
+      $secondary ? theme.orange : darken(0.1, theme.orange)};
+    border-color: ${({ $secondary, theme }) =>
+      $secondary ? theme.orange : darken(0.1, theme.orange)};
+    color: ${({ theme }) => theme.background};
+  }
 
   svg {
     height: 1em;

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -9,8 +9,8 @@ const StyledButton = styled(ResetButton)`
   align-items: center;
   justify-content: center;
   height: 36px;
+  line-height: 0.375rem;
   font-size: 0.875rem;
-  line-height: 1em;
   color: ${({ $secondary, theme }) =>
     $secondary ? theme.orange : theme.background};
   font-weight: bold;

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -22,12 +22,14 @@ const StyledButton = styled(ResetButton)`
   padding: 0 24px;
   // TODO: make raised and add a location button in main pane
 
-  :hover {
-    background: ${({ $secondary, theme }) =>
-      $secondary ? theme.orange : darken(0.1, theme.orange)};
-    border-color: ${({ $secondary, theme }) =>
-      $secondary ? theme.orange : darken(0.1, theme.orange)};
-    color: ${({ theme }) => theme.background};
+  @media ${({ theme }) => theme.device.desktop} {
+    :hover {
+      background: ${({ $secondary, theme }) =>
+        $secondary ? theme.orange : darken(0.1, theme.orange)};
+      border-color: ${({ $secondary, theme }) =>
+        $secondary ? theme.orange : darken(0.1, theme.orange)};
+      color: ${({ theme }) => theme.background};
+    }
   }
 
   svg {

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -8,8 +8,8 @@ const StyledButton = styled(ResetButton)`
   align-items: center;
   justify-content: center;
   height: 36px;
-  font-size: 14px;
-  line-height: 14px;
+  font-size: 0.875rem;
+  line-height: 1em;
   color: ${({ $secondary, theme }) =>
     $secondary ? theme.orange : theme.background};
   font-weight: bold;

--- a/src/components/ui/CaptionInput.js
+++ b/src/components/ui/CaptionInput.js
@@ -27,7 +27,7 @@ const StyledCaptionInput = styled(ListEntry)`
 `
 
 const StyledInput = styled(Input)`
-  font-size: 16px;
+  font-size: 1rem;
   height: 36px;
 `
 

--- a/src/components/ui/CircleIcon.js
+++ b/src/components/ui/CircleIcon.js
@@ -7,14 +7,19 @@ const CircleIcon = styled.div`
   align-items: center;
   background: ${({ backgroundColor }) => backgroundColor};
   padding: 0;
-  width: 36px;
-  height: 36px;
+  width: 1.75rem;
+  height: 1.75rem;
   box-sizing: border-box;
   border-radius: 50%;
   overflow: hidden;
 
   ${StyledIconBase} {
     width: 65%;
+  }
+
+  > svg {
+    width: 1rem;
+    height: auto;
   }
 
   > img {

--- a/src/components/ui/EntryTabs.js
+++ b/src/components/ui/EntryTabs.js
@@ -9,7 +9,7 @@ const EntryTabs = styled(PageTabs)`
     [data-reach-tab] {
       display: flex;
 
-      font-size: 14px;
+      font-size: 0.875rem;
       border-top: none;
 
       border-bottom: 3px solid ${({ theme }) => theme.secondaryBackground};

--- a/src/components/ui/GlobalStyle.js
+++ b/src/components/ui/GlobalStyle.js
@@ -50,6 +50,15 @@ const prepend = (prefix = '', value) => ({ $prepend }) =>
   `${prefix}${$prepend ? '-right' : '-left'}${value && `: ${value};`}`
 
 const GlobalStyle = createGlobalStyle`
+
+  :root {
+    font-size: 16px;
+
+    @media ${({ theme }) => theme.desktop} {
+      font-size: 14px;
+    }
+  }
+
   body {
     font-family: ${({ theme }) => theme.fonts};
     color: ${({ theme }) => theme.text};
@@ -76,25 +85,25 @@ const GlobalStyle = createGlobalStyle`
     font-weight: bold;
   }
 
-  h1 { font-size: 26px; }
-  h2 { font-size: 22.75px; }
-  h3 { font-size: 18px; }
+  h1 { font-size: 1.625rem; }
+  h2 { font-size: 1.375rem; }
+  h3 { font-size: 1.125rem; }
   h4 { 
     font-weight: normal;
-    font-size: 18px;
+    font-size: 1.125rem;
   }
-  h5 { font-size: 14px; }
+  h5 { font-size: 0.875rem; }
   h6 { 
-    font-size: 10px;
+    font-size: 0.625rem;
     text-transform: uppercase;
   }
 
   p {
-    font-size: 18px;
+    font-size: 1.125rem;
   }
 
   p.small {
-    font-size: 16px;
+    font-size: 1rem;
   }
 
   a {

--- a/src/components/ui/IconButton.js
+++ b/src/components/ui/IconButton.js
@@ -37,6 +37,7 @@ const StyledIconButton = styled(ResetButton)`
         border-radius: 50%;
         padding: ${size / 20}px;`}
 
+    width: 100%;
     color: ${({ pressed, raised, theme }) =>
       pressed || raised ? `var(--color)` : theme.secondaryText};
   }

--- a/src/components/ui/IconButton.js
+++ b/src/components/ui/IconButton.js
@@ -52,7 +52,7 @@ const Subscript = styled.div`
   width: 20px;
   height: 20px;
   font-family: ${({ theme }) => theme.fonts};
-  font-size: 10px;
+  font-size: 0.625rem;
   position: absolute;
   bottom: 0;
   right: 0;

--- a/src/components/ui/Input.js
+++ b/src/components/ui/Input.js
@@ -64,7 +64,7 @@ const StyledInput = styled(Input)`
 
   input {
     color: ${({ theme }) => theme.secondaryText};
-    font-size: 16px;
+    font-size: 1rem;
     font-family: ${({ theme }) => theme.fonts};
     padding: 0;
     border: none;

--- a/src/components/ui/Label.js
+++ b/src/components/ui/Label.js
@@ -5,6 +5,7 @@ import { validatedColor } from '../ui/GlobalStyle'
 const Label = styled.label`
   display: block;
   margin: 16px 0 8px 0;
+  font-size: 0.875rem;
   color: ${validatedColor('tertiaryText')};
 `
 

--- a/src/components/ui/LabelTag.js
+++ b/src/components/ui/LabelTag.js
@@ -9,7 +9,7 @@ const LabelTag = styled.span`
   height: 15px;
   padding: 2px;
   margin-left: 5px;
-  font-size: 9px;
+  font-size: 0.5625rem;
   font-weight: bold;
   color: ${validatedColor('text', 'background')};
   background-color: ${validatedColor('secondaryBackground')};

--- a/src/components/ui/LabeledRow.js
+++ b/src/components/ui/LabeledRow.js
@@ -14,7 +14,7 @@ const StyledLabeledInput = styled.div`
     }
 
     > label {
-      font-size: 14px;
+      font-size: 0.875rem;
       font-weight: bold;
       color: ${({ theme }) => theme.secondaryText};
       cursor: pointer;

--- a/src/components/ui/ListEntry.js
+++ b/src/components/ui/ListEntry.js
@@ -30,7 +30,7 @@ const ListContainer = styled.li`
   display: flex;
   flex-direction: row;
   padding: 0 14px;
-  height: 57px;
+  height: 42px;
   align-items: center;
   &:not(:last-child) {
     border-bottom: 1px solid ${({ theme }) => theme.secondaryBackground};

--- a/src/components/ui/ListEntry.js
+++ b/src/components/ui/ListEntry.js
@@ -15,13 +15,13 @@ const Icons = styled.div`
 
 const PrimaryText = styled.div`
   font-weight: bold;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: ${({ theme }) => theme.headerText};
 `
 
 const SecondaryText = styled.div`
   font-weight: normal;
-  font-size: 12px;
+  font-size: 0.75rem;
   color: ${({ theme }) => theme.secondaryText};
 `
 

--- a/src/components/ui/LoadingIndicator.js
+++ b/src/components/ui/LoadingIndicator.js
@@ -1,4 +1,5 @@
 import { Loader } from '@styled-icons/boxicons-regular'
+import { transparentize } from 'polished'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components/macro'
 
@@ -77,7 +78,9 @@ const LoadingIndicator = (props) => {
   const { t } = useTranslation()
   return (
     <LoadingIndicatorWrapper {...props}>
-      <Loader /> {t('Loading...')}
+      <span>
+        <Loader /> {t('Loading...')}
+      </span>
     </LoadingIndicatorWrapper>
   )
 }
@@ -89,6 +92,11 @@ const LoadingOverlay = styled(LoadingIndicator)`
   left: 0;
   width: 100%;
   height: 100%;
+  background-color: ${({ theme }) => transparentize(0.6, theme.background)};
+
+  span {
+    display: none;
+  }
 `
 
 export default LoadingIndicator

--- a/src/components/ui/PageTabs.js
+++ b/src/components/ui/PageTabs.js
@@ -32,7 +32,7 @@ const PageTabs = styled(Tabs)`
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      font-size: 10px;
+      font-size: 0.625rem;
       border-top: 8px solid ${({ theme }) => theme.secondaryBackground};
       border-bottom: none;
 

--- a/src/components/ui/ProgressBarStep.js
+++ b/src/components/ui/ProgressBarStep.js
@@ -20,7 +20,7 @@ const StyledCircleIcon = styled(CircleIcon)`
 
 const StyledProgressBarStep = styled.div`
   position: relative;
-  font-size: 15px;
+  font-size: 0.9375rem;
   color: ${({ $status, theme }) =>
     $status === 'incomplete' ? theme.tertiaryText : theme.orange};
 
@@ -29,7 +29,7 @@ const StyledProgressBarStep = styled.div`
     text-align: center;
     width: 36px;
     margin-top: 4px;
-    font-size: 10px;
+    font-size: 0.625rem;
   }
 
   & + & {

--- a/src/components/ui/Select.js
+++ b/src/components/ui/Select.js
@@ -7,7 +7,7 @@ import { validatedColor } from './GlobalStyle'
 const LIST_ITEM_HEIGHT = 46
 
 const StyledSelect = styled(Select)`
-  font-size: 16px;
+  font-size: 1rem;
 
   .select__clear-indicator,
   .select__indicator-separator {

--- a/src/components/ui/SettingsAccordion.js
+++ b/src/components/ui/SettingsAccordion.js
@@ -19,7 +19,7 @@ const StyledListEntry = styled(ListEntry)`
   width: 100%;
 
   .primaryText {
-    font-size: 15px;
+    font-size: 0.9375rem;
     font-weight: bold;
   }
 `

--- a/src/components/ui/Slider.js
+++ b/src/components/ui/Slider.js
@@ -35,7 +35,7 @@ const StyledSliderInput = styled(SliderInput)`
     background-color: ${({ theme }) => theme.secondaryBackground};
 
     div {
-      font-size: 12px;
+      font-size: 0.75rem;
       margin-top: 20px;
       /* Centers labels under each marker */
       position: absolute;

--- a/src/components/ui/SquareButton.js
+++ b/src/components/ui/SquareButton.js
@@ -14,6 +14,7 @@ const SquareButton = styled(ResetButton)`
   svg {
     color: ${({ disabled, theme }) =>
       disabled ? theme.secondaryBackground : theme.orange};
+    width: 100%;
   }
 `
 

--- a/src/components/ui/Tag.js
+++ b/src/components/ui/Tag.js
@@ -14,7 +14,7 @@ const Tag = styled.li`
   border-radius: 12px;
   height: 23px;
   padding: 0 10px;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: bold;
   background-color: ${({ theme, color, backgroundColor }) =>
     backgroundColor ?? transparentize(0.8, color ?? theme.orange)};

--- a/src/components/ui/Textarea.js
+++ b/src/components/ui/Textarea.js
@@ -6,11 +6,11 @@ const Textarea = styled.textarea`
   border: 1px solid ${validatedColor()};
   box-sizing: border-box;
   border-radius: 12px;
-  padding: 15px 20px;
+  padding: 0.75rem 1rem;
   resize: vertical;
   color: ${({ theme }) => theme.secondaryText};
   font-family: inherit;
-  font-size: 1.125rem;
+  font-size: 1rem;
   width: 100%;
   height: 140px;
 

--- a/src/components/ui/Textarea.js
+++ b/src/components/ui/Textarea.js
@@ -10,7 +10,7 @@ const Textarea = styled.textarea`
   resize: vertical;
   color: ${({ theme }) => theme.secondaryText};
   font-family: inherit;
-  font-size: 18px;
+  font-size: 1.125rem;
   width: 100%;
   height: 140px;
 

--- a/src/components/ui/TileButton.js
+++ b/src/components/ui/TileButton.js
@@ -17,7 +17,7 @@ const StyledResetButton = styled(ResetButton)`
     left: 6px;
     bottom: 5px;
     margin: 0;
-    font-size: 14px;
+    font-size: 0.875rem;
     font-weight: bold;
     color: ${({ theme }) => theme.black};
   }

--- a/src/components/ui/ToggleSwitch.js
+++ b/src/components/ui/ToggleSwitch.js
@@ -7,7 +7,7 @@ const CheckBoxWrapper = styled.div`
 
   label {
     font-weight: bold;
-    font-size: 14px;
+    font-size: 0.875rem;
     color: ${({ theme }) => theme.headerText};
   }
 `

--- a/src/components/ui/TypeTitle.js
+++ b/src/components/ui/TypeTitle.js
@@ -4,13 +4,13 @@ const StyledTypeTitle = styled.div`
   font-family: ${({ theme }) => theme.fonts};
 
   h2 {
-    font-size: 18px;
+    font-size: 1.125rem;
     margin-top: 0px;
     margin-bottom: 0px;
   }
 
   h3 {
-    font-size: 14px;
+    font-size: 0.875rem;
     font-style: italic;
     color: ${({ theme }) => theme.text};
     margin-top: 0px;


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description
- Moved all fonts to use `rem`
- Scaled down fonts on desktop
- Added hover effects to desktop Buttons
- Added hover effects to desktop ListEntries
- Replaced text-shadow with outline on Locations
- Corrected Textarea font-size and padding
- Resized ListEntry contents so lists appear less dense

## Todo
- Type Filtering Fixes:
  - [x] Fix padding between filter checkboxes and text
  - [x] Decrease text and checkbox size
- WebKit
  - [x] Resolve Missing Icons
  - [ ] Vertically center type-filter checkboxes
- [x] Add mask component for list loading
- [x] Change opacity of locations on the satellite layer
- [x] Correct irregular sizes

Fixes #91 and #96 