### PR TITLE
😩 Increase density of displayed clusters

### DIFF
--- a/src/components/map/Cluster.js
+++ b/src/components/map/Cluster.js
@@ -24,7 +24,7 @@ const ClusterContainer = styled(ResetButton)`
   align-items: center;
   border-radius: 100%;
   color: ${({ theme }) => theme.background};
-  background: ${({ theme }) => theme.blue};
+  background: ${({ theme }) => theme.blue}e6;
   box-shadow: 0 0 4px 1px ${({ theme }) => theme.shadow};
   transform: translate(-50%, -50%);
   line-height: 0;

--- a/src/redux/mapSlice.js
+++ b/src/redux/mapSlice.js
@@ -37,7 +37,9 @@ export const fetchMapClusters = createAsyncThunk(
   'map/fetchMapClusters',
   async (_, { getState }) => {
     const state = getState()
-    return await getClusters(selectParams(state, { zoom: state.map.view.zoom }))
+    return await getClusters(
+      selectParams(state, { zoom: state.map.view.zoom + 1 }),
+    )
   },
 )
 


### PR DESCRIPTION
Just because the map feels a little empty when clusterZoom = mapZoom.

- Display {zoom + 1} clusters on {zoom} map.
- Make cluster background slightly transparent for when they overlap.

If we wanted to match fallingfruit.org exactly, it would be clusterZoom = mapZoom > 3 ? mapZoom + 1 : mapZoom. I think we did this to reduce overlaps for mapZooms 0-3. But I think it looks kinda cool with more stuff on the map.

## Status:

:rocket: Ready

<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

More clusters!

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

![image](https://user-images.githubusercontent.com/377523/120975028-160b4000-c771-11eb-9bad-42598172d63d.png)