### PR TITLE
More clear map tile labels

### DIFF
--- a/src/components/ui/TileButton.js
+++ b/src/components/ui/TileButton.js
@@ -1,3 +1,4 @@
+import { transparentize } from 'polished'
 import styled from 'styled-components/macro'
 
 import ResetButton from './ResetButton'
@@ -12,6 +13,18 @@ const StyledResetButton = styled(ResetButton)`
     ${({ $selected, theme }) => ($selected ? theme.blue : theme.background)};
   overflow: hidden;
 
+  .mask {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+      transparent,
+      ${({ theme }) => transparentize(0.15, theme.headerText)}
+    );
+  }
+
   p {
     position: absolute;
     left: 6px;
@@ -19,7 +32,7 @@ const StyledResetButton = styled(ResetButton)`
     margin: 0;
     font-size: 0.875rem;
     font-weight: bold;
-    color: ${({ theme }) => theme.black};
+    color: ${({ theme }) => theme.background};
   }
 
   > img {
@@ -31,6 +44,7 @@ const StyledResetButton = styled(ResetButton)`
 
 const TileButton = ({ label, children, ...props }) => (
   <StyledResetButton {...props}>
+    <div className="mask" />
     <p>{label}</p>
     {children}
   </StyledResetButton>


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

- Adds mask over map tile labels for contrast

Fixes #139 

## Screenshots

<img width="362" alt="Screen Shot 2021-10-17 at 10 20 05 PM" src="https://user-images.githubusercontent.com/19193347/137664458-d2b27334-f176-43f0-941b-e121f0b77265.png">
<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
