### PR TITLE
🪝 Add useAppHistory hook

### DIFF
--- a/src/components/about/PageTemplate.js
+++ b/src/components/about/PageTemplate.js
@@ -1,7 +1,7 @@
 import { ArrowBack } from '@styled-icons/boxicons-regular'
-import { useHistory } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
+import { useAppHistory } from '../../utils/useAppHistory'
 import { useIsMobile } from '../../utils/useBreakpoint'
 import BackButton from '../ui/BackButton'
 
@@ -89,7 +89,7 @@ const StyledBackButton = styled(BackButton)`
 
 const PageTemplate = ({ children }) => {
   // TODO: migrate to custom hook for map state
-  const history = useHistory()
+  const history = useAppHistory()
   const isMobile = useIsMobile()
 
   const onClickBackButton = () => history.go(-1)

--- a/src/components/desktop/MainPane.js
+++ b/src/components/desktop/MainPane.js
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 import styled from 'styled-components/macro'
 
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import Filter from '../filter/Filter'
 import Search from '../search/Search'
@@ -43,7 +42,7 @@ const MainPane = () => {
         secondary
         onClick={() =>
           history.push({
-            pathname: getPathWithMapState('/map/entry/new'),
+            pathname: '/map/entry/new',
             state: { fromPage: '/map' },
           })
         }
@@ -53,7 +52,7 @@ const MainPane = () => {
       <SettingsButton
         onClick={() =>
           history.push({
-            pathname: getPathWithMapState('/settings'),
+            pathname: '/settings',
             state: { fromPage: '/map' },
           })
         }

--- a/src/components/desktop/MainPane.js
+++ b/src/components/desktop/MainPane.js
@@ -1,8 +1,8 @@
 import { useEffect } from 'react'
-import { useHistory } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import Filter from '../filter/Filter'
 import Search from '../search/Search'
 import Button from '../ui/Button'
@@ -34,7 +34,7 @@ const MainPane = () => {
     console.log('mainpane mount')
     return () => console.log('mainpane unmount')
   }, [])
-  const history = useHistory()
+  const history = useAppHistory()
   return (
     <Container>
       <Search />

--- a/src/components/desktop/NavBack.js
+++ b/src/components/desktop/NavBack.js
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import BackButton from '../ui/BackButton'
 
@@ -26,7 +25,7 @@ const NavBack = ({ isEntry }) => {
 
   const handleBackButtonClick = () => {
     // Default to going back to the map. This occurs when the user opens /entry/{typeId} directly
-    history.push(getPathWithMapState(state?.fromPage ?? '/map'))
+    history.push(state?.fromPage ?? '/map')
   }
 
   return (

--- a/src/components/desktop/NavBack.js
+++ b/src/components/desktop/NavBack.js
@@ -1,9 +1,10 @@
 import { ArrowBack } from '@styled-icons/boxicons-regular'
 import { useTranslation } from 'react-i18next'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import BackButton from '../ui/BackButton'
 
 const StyledNavBack = styled.div`
@@ -19,7 +20,7 @@ const StyledNavBack = styled.div`
 
 // TODO: redefine NavBack to accept a callback and label instead of isEntry
 const NavBack = ({ isEntry }) => {
-  const history = useHistory()
+  const history = useAppHistory()
   const { state } = useLocation()
   const { t } = useTranslation()
 

--- a/src/components/entry/EntryDrawer.js
+++ b/src/components/entry/EntryDrawer.js
@@ -2,9 +2,9 @@ import { useWindowSize } from '@reach/window-size'
 import { ArrowBack as ArrowBackIcon } from '@styled-icons/boxicons-regular'
 import { Pencil as PencilIcon } from '@styled-icons/boxicons-solid'
 import { useEffect, useRef, useState } from 'react'
-import { useHistory } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
+import { useAppHistory } from '../../utils/useAppHistory'
 import IconButton from '../ui/IconButton'
 import Card from './Card'
 import Carousel from './Carousel'
@@ -101,7 +101,7 @@ const EntryDrawer = ({
   entryOverview,
   entryReviews,
 }) => {
-  const history = useHistory()
+  const history = useAppHistory()
   const cardRef = useRef()
   const [drawer, setDrawer] = useState()
   const [isFullScreen, setIsFullScreen] = useState(false)

--- a/src/components/entry/EntryNav.js
+++ b/src/components/entry/EntryNav.js
@@ -1,12 +1,13 @@
 import { Map, Pencil } from '@styled-icons/boxicons-solid'
-import { useHistory, useLocation, useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import IconButton from '../ui/IconButton'
 import TopBarNav from '../ui/TopBarNav'
 
 const EntryNav = () => {
-  const history = useHistory()
+  const history = useAppHistory()
   const { state } = useLocation()
   const { id } = useParams()
 

--- a/src/components/entry/EntryNav.js
+++ b/src/components/entry/EntryNav.js
@@ -1,7 +1,6 @@
 import { Map, Pencil } from '@styled-icons/boxicons-solid'
 import { useLocation, useParams } from 'react-router-dom'
 
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import IconButton from '../ui/IconButton'
 import TopBarNav from '../ui/TopBarNav'
@@ -14,7 +13,7 @@ const EntryNav = () => {
   const onBackButtonClick = () => {
     // TODO: extract into routing utils
     // Default to going back to the list. This occurs when the user opens /entry/{typeId} directly
-    history.push(getPathWithMapState(state?.fromPage ?? '/list'))
+    history.push(state?.fromPage ?? '/list')
   }
 
   const onEditButtonClick = () => {
@@ -23,7 +22,7 @@ const EntryNav = () => {
   }
 
   const onMapButtonClick = () => {
-    history.push(getPathWithMapState(`/map/entry/${id}`))
+    history.push(`/map/entry/${id}`)
   }
 
   return (

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -8,7 +8,6 @@ import styled from 'styled-components/macro'
 
 import { setStreetView, zoomIn } from '../../redux/mapSlice'
 import { useTypesById } from '../../redux/useTypesById'
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { hasSeasonality } from '../../utils/locationInfo'
 import { useAppHistory } from '../../utils/useAppHistory'
 import { useIsDesktop } from '../../utils/useBreakpoint'
@@ -93,7 +92,7 @@ const EntryOverview = ({ locationData, className }) => {
 
   const handleStreetView = () => {
     if (!isDesktop) {
-      history.push(getPathWithMapState(`/map/entry/${locationData.id}`))
+      history.push(`/map/entry/${locationData.id}`)
     }
 
     // TODO: change setTimeout to make it wait for map component to mount

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -3,13 +3,14 @@ import { Flag, Map, Star } from '@styled-icons/boxicons-solid'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { Link, useHistory } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { setStreetView, zoomIn } from '../../redux/mapSlice'
 import { useTypesById } from '../../redux/useTypesById'
 import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { hasSeasonality } from '../../utils/locationInfo'
+import { useAppHistory } from '../../utils/useAppHistory'
 import { useIsDesktop } from '../../utils/useBreakpoint'
 import { ReportModal } from '../form/ReportModal'
 import Button from '../ui/Button'
@@ -74,7 +75,7 @@ const Description = styled.section`
 const EntryOverview = ({ locationData, className }) => {
   const isDesktop = useIsDesktop()
   const { getLocationTypes } = useTypesById()
-  const history = useHistory()
+  const history = useAppHistory()
   const [isReportModalOpen, setIsReportModalOpen] = useState(false)
   const dispatch = useDispatch()
   const currentStreetView = useSelector((state) => state.map.streetView)

--- a/src/components/entry/EntryReviews.js
+++ b/src/components/entry/EntryReviews.js
@@ -1,6 +1,5 @@
 import { useSelector } from 'react-redux'
 
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import { ReviewForm } from '../form/ReviewForm'
 import { TextContent } from './Entry'
@@ -30,7 +29,7 @@ const EntryReviews = ({ reviews, onImageClick, onReviewSubmit }) => {
           onImageClick={(imageIndex) => onImageClick(review.index, imageIndex)}
           onEditClick={() =>
             history.push({
-              pathname: getPathWithMapState(`/review/${review.id}/edit`),
+              pathname: `/review/${review.id}/edit`,
               state: {
                 fromPage: history.location.pathname,
               },

--- a/src/components/entry/EntryReviews.js
+++ b/src/components/entry/EntryReviews.js
@@ -1,14 +1,14 @@
 import { useSelector } from 'react-redux'
-import { useHistory } from 'react-router-dom'
 
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import { ReviewForm } from '../form/ReviewForm'
 import { TextContent } from './Entry'
 import Review from './Review'
 import ReviewSummary from './ReviewSummary'
 
 const EntryReviews = ({ reviews, onImageClick, onReviewSubmit }) => {
-  const history = useHistory()
+  const history = useAppHistory()
   const user = useSelector((state) => state.auth.user)
 
   const indexedReviews = reviews.map((review, index) => ({ ...review, index }))

--- a/src/components/form/EditableForm.js
+++ b/src/components/form/EditableForm.js
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
-import { useHistory, useRouteMatch } from 'react-router-dom'
+import { useRouteMatch } from 'react-router-dom'
 
 import { getLocationById, getReviewById } from '../../utils/api'
+import { useAppHistory } from '../../utils/useAppHistory'
 import { Page } from '../entry/Entry'
 import { LocationForm, locationToForm } from './LocationForm'
 import { ReviewForm, reviewToForm } from './ReviewForm'
@@ -16,7 +17,7 @@ const EditableForm = ({
   const {
     params: { id },
   } = useRouteMatch()
-  const history = useHistory()
+  const history = useAppHistory()
 
   const [formData, setFormData] = useState(null)
 

--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import styled from 'styled-components/macro'
 
@@ -8,6 +8,7 @@ import { useTypesById } from '../../redux/useTypesById'
 import { fetchLocations } from '../../redux/viewChange'
 import { addLocation, editLocation } from '../../utils/api'
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import Button from '../ui/Button'
 import Label from '../ui/Label'
 import { Optional } from '../ui/LabelTag'
@@ -204,7 +205,7 @@ export const LocationForm = ({
   stepped,
 }) => {
   // TODO: create a "going back" util
-  const history = useHistory()
+  const history = useAppHistory()
   const { state } = useLocation()
   const { typesById } = useTypesById()
 

--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -7,7 +7,6 @@ import styled from 'styled-components/macro'
 import { useTypesById } from '../../redux/useTypesById'
 import { fetchLocations } from '../../redux/viewChange'
 import { addLocation, editLocation } from '../../utils/api'
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import Button from '../ui/Button'
 import Label from '../ui/Label'
@@ -239,7 +238,7 @@ export const LocationForm = ({
     </Step>
   ))
 
-  onSubmit = onSubmit ?? (() => history.push(getPathWithMapState('/map')))
+  onSubmit = onSubmit ?? (() => history.push('/map'))
   const handleSubmit = async ({
     'g-recaptcha-response': recaptcha,
     review,
@@ -298,9 +297,7 @@ export const LocationForm = ({
             <Button
               secondary
               type="button"
-              onClick={() =>
-                history.push(getPathWithMapState(state?.fromPage ?? '/map'))
-              }
+              onClick={() => history.push(state?.fromPage ?? '/map')}
             >
               Cancel
             </Button>

--- a/src/components/form/LocationNav.js
+++ b/src/components/form/LocationNav.js
@@ -1,8 +1,9 @@
 import { Check, X } from '@styled-icons/boxicons-regular'
-import { Route, Switch, useHistory } from 'react-router-dom'
+import { Route, Switch } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import { theme } from '../ui/GlobalStyle'
 import IconButton from '../ui/IconButton'
 import TopBarNav from '../ui/TopBarNav'
@@ -12,7 +13,7 @@ const Instructions = styled.span`
 `
 
 const LocationNav = () => {
-  const history = useHistory()
+  const history = useAppHistory()
 
   return (
     <Switch>

--- a/src/components/form/LocationNav.js
+++ b/src/components/form/LocationNav.js
@@ -2,7 +2,6 @@ import { Check, X } from '@styled-icons/boxicons-regular'
 import { Route, Switch } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import { theme } from '../ui/GlobalStyle'
 import IconButton from '../ui/IconButton'
@@ -19,7 +18,7 @@ const LocationNav = () => {
     <Switch>
       <Route path="/map/entry/new/details">
         <TopBarNav
-          onBack={() => history.push(getPathWithMapState('/map/entry/new'))}
+          onBack={() => history.push('/map/entry/new')}
           title="New Location"
         />
       </Route>
@@ -36,7 +35,7 @@ const LocationNav = () => {
                 raised
                 size={54}
                 onClick={() => {
-                  history.push(getPathWithMapState('/map'))
+                  history.push('/map')
                 }}
               />
               <IconButton
@@ -46,7 +45,7 @@ const LocationNav = () => {
                 size={54}
                 color={theme.green}
                 onClick={() => {
-                  history.push(getPathWithMapState('/map/entry/new/details'))
+                  history.push('/map/entry/new/details')
                 }}
               />
             </>

--- a/src/components/list/InfiniteList.js
+++ b/src/components/list/InfiniteList.js
@@ -1,7 +1,7 @@
-import { useHistory } from 'react-router-dom'
 import InfiniteLoader from 'react-window-infinite-loader'
 
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import EntryList from './EntryList'
 
 const InfiniteList = ({
@@ -12,7 +12,7 @@ const InfiniteList = ({
   height,
   width,
 }) => {
-  const history = useHistory()
+  const history = useAppHistory()
 
   // eslint-disable-next-line no-empty-function
   const loadMoreItems = isNextPageLoading ? () => {} : loadNextPage

--- a/src/components/list/InfiniteList.js
+++ b/src/components/list/InfiniteList.js
@@ -1,6 +1,5 @@
 import InfiniteLoader from 'react-window-infinite-loader'
 
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import EntryList from './EntryList'
 
@@ -21,7 +20,7 @@ const InfiniteList = ({
 
   const handleEntryClick = (id) => {
     history.push({
-      pathname: getPathWithMapState(`/list/entry/${id}`),
+      pathname: `/list/entry/${id}`,
       state: { fromPage: '/list' },
     })
   }

--- a/src/components/list/PagedList.js
+++ b/src/components/list/PagedList.js
@@ -7,7 +7,6 @@ import styled from 'styled-components/macro'
 import { fetchListLocations, setUpdateOnMapMove } from '../../redux/listSlice'
 import { setHoveredLocationId } from '../../redux/mapSlice'
 import { getIsShowingClusters } from '../../redux/viewChange'
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import Checkbox from '../ui/Checkbox'
 import LabeledRow from '../ui/LabeledRow'
@@ -63,7 +62,7 @@ const PagedList = () => {
 
   const handleEntryClick = (id) => {
     history.push({
-      pathname: getPathWithMapState(`/list/entry/${id}`),
+      pathname: `/list/entry/${id}`,
       state: { fromPage: '/list' },
     })
     dispatch(setHoveredLocationId(null))

--- a/src/components/list/PagedList.js
+++ b/src/components/list/PagedList.js
@@ -1,7 +1,6 @@
 import { ChevronLeft, ChevronRight } from '@styled-icons/boxicons-regular'
 import { debounce } from 'debounce'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory } from 'react-router-dom'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import styled from 'styled-components/macro'
 
@@ -9,6 +8,7 @@ import { fetchListLocations, setUpdateOnMapMove } from '../../redux/listSlice'
 import { setHoveredLocationId } from '../../redux/mapSlice'
 import { getIsShowingClusters } from '../../redux/viewChange'
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import Checkbox from '../ui/Checkbox'
 import LabeledRow from '../ui/LabeledRow'
 import LoadingIndicator, { LoadingOverlay } from '../ui/LoadingIndicator'
@@ -47,7 +47,7 @@ const PageNav = styled.div`
 `
 
 const PagedList = () => {
-  const history = useHistory()
+  const history = useAppHistory()
 
   const dispatch = useDispatch()
   const offset = useSelector((state) => state.list.offset)

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -12,7 +12,6 @@ import {
 import { useTypesById } from '../../redux/useTypesById'
 import { getAllLocations, viewChangeAndFetch } from '../../redux/viewChange'
 import { bootstrapURLKeys } from '../../utils/bootstrapURLKeys'
-import { getPathWithMapState } from '../../utils/getInitialUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import AddLocationButton from '../ui/AddLocationButton'
 import AddLocationPin from '../ui/AddLocationPin'
@@ -59,13 +58,13 @@ const MapPage = ({ isDesktop }) => {
 
   const handleLocationClick = (location) => {
     history.push({
-      pathname: getPathWithMapState(`/map/entry/${location.id}`),
+      pathname: `/map/entry/${location.id}`,
       state: { fromPage: '/map' },
     })
   }
 
   const handleAddLocationClick = () => {
-    history.push(getPathWithMapState('/map/entry/new'))
+    history.push('/map/entry/new')
   }
 
   return (

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory, useRouteMatch } from 'react-router-dom'
+import { useRouteMatch } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import {
@@ -13,6 +13,7 @@ import { useTypesById } from '../../redux/useTypesById'
 import { getAllLocations, viewChangeAndFetch } from '../../redux/viewChange'
 import { bootstrapURLKeys } from '../../utils/bootstrapURLKeys'
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import AddLocationButton from '../ui/AddLocationButton'
 import AddLocationPin from '../ui/AddLocationPin'
 import LoadingIndicator from '../ui/LoadingIndicator'
@@ -27,7 +28,7 @@ const BottomLeftLoadingIndicator = styled(LoadingIndicator)`
 `
 
 const MapPage = ({ isDesktop }) => {
-  const history = useHistory()
+  const history = useAppHistory()
   const match = useRouteMatch({
     path: '/(map|list)/entry/:entryId/:geocoord?',
     exact: true,

--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -2,11 +2,11 @@ import { ChevronRight } from '@styled-icons/boxicons-solid'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { logout } from '../../redux/authSlice'
 import { updateSettings } from '../../redux/settingsSlice'
+import { useAppHistory } from '../../utils/useAppHistory'
 import Button from '../ui/Button'
 import ButtonToggle from '../ui/ButtonToggle'
 import Checkbox from '../ui/Checkbox'
@@ -97,7 +97,7 @@ const SettingsPage = ({ desktop }) => {
   const user = useSelector((state) => state.auth.user)
 
   // TODO: migrate to custom hook for map state
-  const history = useHistory()
+  const history = useAppHistory()
 
   const [overrideDataLanguage, setOverrideDataLanguage] = useState(false)
   const { t, i18n } = useTranslation()

--- a/src/components/table/ImportsTable.jsx
+++ b/src/components/table/ImportsTable.jsx
@@ -1,8 +1,8 @@
 import { Search as SearchIcon } from '@styled-icons/boxicons-regular'
 import React, { useEffect, useState } from 'react'
-import { useHistory } from 'react-router-dom'
 
 import { getImports } from '../../utils/api'
+import { useAppHistory } from '../../utils/useAppHistory'
 import Input from '../ui/Input'
 import DataTable from './DataTable'
 import { FORMATTERS } from './DataTableProperties'
@@ -45,7 +45,7 @@ const ImportsTable = () => {
   const [data, setData] = useState([])
   const [isLoading, setIsLoading] = useState(true)
   const [filterText, setFilterText] = React.useState('')
-  const history = useHistory()
+  const history = useAppHistory()
 
   useEffect(() => {
     const getImportData = async () => {

--- a/src/utils/useAppHistory.js
+++ b/src/utils/useAppHistory.js
@@ -1,0 +1,30 @@
+import { getPathWithMapState } from './getInitialUrl'
+
+/**
+ * Wraps useAppHistory from react-router-dom to automatically preserve
+ * map state in URL.
+ */
+export const useAppHistory = () => {
+  const history = useAppHistory()
+
+  const pushWithMapState = (to, state) => {
+    let newTo
+    if (typeof to === 'string') {
+      newTo = getPathWithMapState(newTo)
+    } else {
+      newTo = { ...to }
+      if (to.pathname != null) {
+        newTo.pathname = getPathWithMapState(to.pathname)
+      }
+    }
+
+    history.push(newTo, state)
+  }
+
+  history.push = pushWithMapState
+
+  return history
+}
+
+// TODO: create a history listener/context for consistent back navigation?
+// https://stackoverflow.com/a/67477708/2411756

--- a/src/utils/useAppHistory.js
+++ b/src/utils/useAppHistory.js
@@ -1,3 +1,5 @@
+import { useHistory } from 'react-router-dom'
+
 import { getPathWithMapState } from './getInitialUrl'
 
 /**
@@ -5,12 +7,13 @@ import { getPathWithMapState } from './getInitialUrl'
  * map state in URL.
  */
 export const useAppHistory = () => {
-  const history = useAppHistory()
+  const history = useHistory()
 
   const pushWithMapState = (to, state) => {
+    console.log(to, state)
     let newTo
     if (typeof to === 'string') {
-      newTo = getPathWithMapState(newTo)
+      newTo = getPathWithMapState(to)
     } else {
       newTo = { ...to }
       if (to.pathname != null) {
@@ -21,9 +24,7 @@ export const useAppHistory = () => {
     history.push(newTo, state)
   }
 
-  history.push = pushWithMapState
-
-  return history
+  return { ...history, push: pushWithMapState }
 }
 
 // TODO: create a history listener/context for consistent back navigation?

--- a/src/utils/useRoutedTabs.js
+++ b/src/utils/useRoutedTabs.js
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
-import { matchPath, useHistory, useLocation } from 'react-router-dom'
+import { matchPath, useLocation } from 'react-router-dom'
 
 import { getPathWithMapState } from './getInitialUrl'
+import { useAppHistory } from './useAppHistory'
 
 /**
  * Hook to get and set the current tab, while updating the URL location on tab change.
@@ -11,7 +12,7 @@ import { getPathWithMapState } from './getInitialUrl'
  */
 const useRoutedTabs = (tabPaths, defaultTabIndex = 0) => {
   const { pathname } = useLocation()
-  const history = useHistory()
+  const history = useAppHistory()
 
   const [tabIndex, setTabIndex] = useState(defaultTabIndex)
 

--- a/src/utils/useRoutedTabs.js
+++ b/src/utils/useRoutedTabs.js
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import { matchPath, useLocation } from 'react-router-dom'
 
-import { getPathWithMapState } from './getInitialUrl'
 import { useAppHistory } from './useAppHistory'
 
 /**
@@ -39,15 +38,11 @@ const useRoutedTabs = (tabPaths, defaultTabIndex = 0) => {
         strict: false,
       })
     ) {
-      history.push(getPathWithMapState(tabPaths[tabIndex]))
+      history.push(tabPaths[tabIndex])
     } else {
       // otherwise push new shallow while keeping deep link
       const segments = pathname.split('/')
-      history.push(
-        getPathWithMapState(
-          [tabPaths[tabIndex], ...segments.splice(2)].join('/'),
-        ),
-      )
+      history.push([tabPaths[tabIndex], ...segments.splice(2)].join('/'))
     }
   }
 


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

* Wraps useHistory from react-router-dom to automatically preserve map state in URL when pushing new routes.
* Avoids the need for getPathWithMapState
* Always use `useAppHistory` instead of `useHistory` in case we need future functionality

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #232 

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
