### PR TITLE
🎛 Filter Render Delay

### DIFF
--- a/src/components/filter/Filter.js
+++ b/src/components/filter/Filter.js
@@ -1,5 +1,5 @@
 import { debounce } from 'debounce'
-import { useMemo, useState } from 'react'
+import { useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components/macro'
@@ -16,6 +16,7 @@ import {
 } from './CheckboxFilters'
 import FilterButtons from './FilterButtons'
 import RCTreeSelect from './RCTreeSelect'
+import RCTreeSelectSkeleton from './RCTreeSelectSkeleton'
 
 const StyledFilter = styled.div`
   box-sizing: border-box;
@@ -78,6 +79,8 @@ const Filter = ({ isOpen }) => {
     [setSearchValue],
   )
 
+  const didMount = useRef(false)
+
   const dispatch = useDispatch()
   const { typesById } = useTypesById()
   const filters = useSelector((state) => state.filter)
@@ -114,6 +117,12 @@ const Filter = ({ isOpen }) => {
     ],
   )
 
+  useLayoutEffect(() => {
+    if (didMount.current === false) {
+      didMount.current = true
+    }
+  })
+
   const { t } = useTranslation()
   return isOpen ? (
     <StyledFilter>
@@ -138,19 +147,23 @@ const Filter = ({ isOpen }) => {
             onDeselectAllClick={() => dispatch(selectionChanged([]))}
           />
         </TreeFiltersContainer>
-        <RCTreeSelect
-          data={treeDataWithUpdatedCounts}
-          loading={isLoading}
-          onChange={(selectedTypes) =>
-            dispatch(
-              selectionChanged(
-                selectedTypes.filter((t) => !t.includes('root')),
-              ),
-            )
-          }
-          checkedTypes={types}
-          searchValue={searchValue}
-        />
+        {didMount.current ? (
+          <RCTreeSelect
+            data={treeDataWithUpdatedCounts}
+            loading={isLoading}
+            onChange={(selectedTypes) =>
+              dispatch(
+                selectionChanged(
+                  selectedTypes.filter((t) => !t.includes('root')),
+                ),
+              )
+            }
+            checkedTypes={types}
+            searchValue={searchValue}
+          />
+        ) : (
+          <RCTreeSelectSkeleton />
+        )}
       </div>
       <MuniAndInvasiveCheckboxFilters>
         <CheckboxFilters

--- a/src/components/filter/RCTreeSelectSkeleton.js
+++ b/src/components/filter/RCTreeSelectSkeleton.js
@@ -1,0 +1,27 @@
+import Skeleton from 'react-loading-skeleton'
+import styled from 'styled-components/macro'
+
+const TreeSelectContainer = styled.div`
+  height: 100%;
+  border: 1px solid ${({ theme }) => theme.secondaryBackground};
+  border-radius: 7px;
+  padding: 0.5em;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  margin-bottom: 12px;
+  @media ${({ theme }) => theme.device.mobile} {
+    height: 50vh;
+  }
+`
+
+const RCTreeSelectSkeleton = () => (
+  <TreeSelectContainer>
+    {new Array(32).fill(null).map((_, idx) => (
+      <Skeleton key={idx} width={Math.random() * 150 + 150} />
+    ))}
+  </TreeSelectContainer>
+)
+
+export default RCTreeSelectSkeleton

--- a/src/components/ui/GlobalStyle.js
+++ b/src/components/ui/GlobalStyle.js
@@ -59,6 +59,7 @@ const prepend =
 
 const zIndex = {
   mobileTablist: 1,
+  topBar: 11,
   modal: 30,
 }
 

--- a/src/components/ui/TopBar.js
+++ b/src/components/ui/TopBar.js
@@ -1,11 +1,13 @@
 import styled from 'styled-components/macro'
 
+import { zIndex } from './GlobalStyle'
+
 const TopBar = styled.div`
   position: absolute;
   left: 0;
   right: 0;
   top: 0;
-  z-index: 1;
+  z-index: ${zIndex.topBar};
   background: ${({ theme }) => theme.background};
   filter: drop-shadow(0px -1px 8px ${({ theme }) => theme.shadow});
   padding: 16px;


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready
## Description

Delays filter rendering until rest of map page mounts. Prevents seconds of delay when clicking the map page from another.

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
