### PR TITLE
🐛 Miscellaneous bug fixes

### DIFF
--- a/src/components/auth/AccountPage.js
+++ b/src/components/auth/AccountPage.js
@@ -8,6 +8,7 @@ import * as Yup from 'yup'
 import { checkAuth, logout } from '../../redux/authSlice'
 import { editUser, getUser } from '../../utils/api'
 import { getPathWithMapState } from '../../utils/getInitialUrl'
+import { useAppHistory } from '../../utils/useAppHistory'
 import { PageScrollWrapper, PageTemplate } from '../about/PageTemplate'
 import { Input, Textarea } from '../form/FormikWrappers'
 import Button from '../ui/Button'
@@ -42,6 +43,7 @@ const AccountPage = () => {
   const dispatch = useDispatch()
   const isLoading = useSelector((state) => state.auth.isLoading)
   const isLoggedIn = useSelector((state) => !!state.auth.user)
+  const history = useAppHistory()
 
   const [user, setUser] = useState()
 
@@ -169,7 +171,8 @@ const AccountPage = () => {
             <br />
             <Button
               onClick={() => {
-                dispatch(logout)
+                dispatch(logout())
+                history.push('/map')
               }}
             >
               Logout

--- a/src/components/desktop/NavBack.js
+++ b/src/components/desktop/NavBack.js
@@ -32,7 +32,11 @@ const NavBack = ({ isEntry }) => {
 
   const handleBackButtonClick = () => {
     // Default to going back to the map. This occurs when the user opens /entry/{typeId} directly
-    history.push(state?.fromPage ?? '/map')
+    if (isEditingEntry) {
+      history.push(match.url)
+    } else {
+      history.push(state?.fromPage ?? '/map')
+    }
   }
 
   return (

--- a/src/components/desktop/NavBack.js
+++ b/src/components/desktop/NavBack.js
@@ -1,5 +1,6 @@
 import { ArrowBack, Pencil } from '@styled-icons/boxicons-regular'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { useLocation, useRouteMatch } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
@@ -25,6 +26,7 @@ const NavBack = ({ isEntry }) => {
   const history = useAppHistory()
   const { state } = useLocation()
   const { t } = useTranslation()
+  const isLoggedIn = useSelector((state) => !!state.auth.user)
   const match = useRouteMatch('/entry/:id')
   const entryId = match?.params.id
 
@@ -45,7 +47,7 @@ const NavBack = ({ isEntry }) => {
         <ArrowBack />
         {t('Back')}
       </BackButton>
-      {isEntry && match && !isEditingEntry && (
+      {isEntry && match && !isEditingEntry && isLoggedIn && (
         <BackButton onClick={() => history.push(`/entry/${entryId}/edit`)}>
           <Pencil />
           Edit

--- a/src/components/desktop/NavBack.js
+++ b/src/components/desktop/NavBack.js
@@ -28,6 +28,8 @@ const NavBack = ({ isEntry }) => {
   const match = useRouteMatch('/entry/:id')
   const entryId = match?.params.id
 
+  const isEditingEntry = useRouteMatch('/entry/:id/edit')
+
   const handleBackButtonClick = () => {
     // Default to going back to the map. This occurs when the user opens /entry/{typeId} directly
     history.push(state?.fromPage ?? '/map')
@@ -39,7 +41,7 @@ const NavBack = ({ isEntry }) => {
         <ArrowBack />
         {t('Back')}
       </BackButton>
-      {isEntry && (
+      {isEntry && match && !isEditingEntry && (
         <BackButton onClick={() => history.push(`/entry/${entryId}/edit`)}>
           <Pencil />
           Edit

--- a/src/components/filter/Filter.js
+++ b/src/components/filter/Filter.js
@@ -4,9 +4,8 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components/macro'
 
-import { selectionChanged, setFilters } from '../../redux/filterSlice'
+import { filtersChanged, selectionChanged } from '../../redux/filterSlice'
 import { useTypesById } from '../../redux/useTypesById'
-import { fetchLocations } from '../../redux/viewChange'
 import { updateTreeCounts } from '../../utils/buildTypeSchema'
 import Input from '../ui/Input'
 import {
@@ -137,7 +136,7 @@ const Filter = ({ isOpen }) => {
             values={filters}
             fields={TREE_SHOW_CHECKBOX_FIELDS}
             onChange={(values) => {
-              dispatch(setFilters(values))
+              dispatch(filtersChanged(values))
             }}
           />
           <FilterButtons
@@ -170,8 +169,7 @@ const Filter = ({ isOpen }) => {
           values={filters}
           fields={MUNI_AND_INVASIVE_CHECKBOX_FIELDS}
           onChange={(values) => {
-            dispatch(setFilters(values))
-            dispatch(fetchLocations())
+            dispatch(filtersChanged(values))
           }}
         />
       </MuniAndInvasiveCheckboxFilters>

--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -196,7 +196,7 @@ const formToLocation = ({
   description,
   season_start: season_start?.value ?? null,
   season_stop: season_stop?.value ?? null,
-  access: access?.value,
+  access: access?.value ?? null,
   unverified: false,
 })
 

--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -72,6 +72,7 @@ const INITIAL_LOCATION_VALUES = {
 const StyledLocationForm = styled.div`
   box-sizing: border-box;
   width: 100%;
+  height: 100%;
   padding: 0 10px;
   overflow: auto;
 

--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -72,9 +72,12 @@ const INITIAL_LOCATION_VALUES = {
 const StyledLocationForm = styled.div`
   box-sizing: border-box;
   width: 100%;
-  height: 100%;
   padding: 0 10px;
   overflow: auto;
+
+  @media ${({ theme }) => theme.device.desktop} {
+    height: 100%;
+  }
 
   @media ${({ theme }) => theme.device.mobile} {
     padding: 8px 27px 20px;

--- a/src/components/map/TrackLocationButton.js
+++ b/src/components/map/TrackLocationButton.js
@@ -20,11 +20,11 @@ const SpinningLoader = styled(LoaderAlt)`
   animation: 1s linear ${spin} infinite;
 `
 
-const getTrackLocationColor = ({ $disabled, $active }) =>
-  $active && !$disabled ? 'blue' : 'tertiaryText'
+const getTrackLocationColor = ({ disabled, $active }) =>
+  $active && !disabled ? 'blue' : 'tertiaryText'
 
-const TrackLocationIcon = ({ $disabled, $loading, ...props }) => {
-  if ($disabled) {
+const TrackLocationIcon = ({ disabled, $loading, ...props }) => {
+  if (disabled) {
     return <XCircle {...props} /> // TODO: replace this with a specific "disabled geolocation" icon, like Google Maps has
   } else if ($loading) {
     return <SpinningLoader {...props} />
@@ -76,7 +76,7 @@ const TrackLocationButton = ({ isIcon }) => {
 
   return (
     <TrackLocationBtn
-      $disabled={geolocation?.error}
+      disabled={geolocation?.error}
       $loading={geolocation?.loading}
       $active={isTrackingLocation}
       onClick={() => {

--- a/src/redux/filterSlice.js
+++ b/src/redux/filterSlice.js
@@ -47,8 +47,6 @@ export const filterSlice = createSlice({
     showOnlyOnMap: false,
   },
   reducers: {
-    setFilters: (state, action) => ({ ...state, ...action.payload }),
-
     openFilter: (state) => {
       state.isOpen = true
     },
@@ -72,9 +70,7 @@ export const filterSlice = createSlice({
       state.isLoading = false
     },
 
-    [updateSelection]: (state, action) => {
-      state.types = action.payload
-    },
+    [updateSelection]: (state, action) => ({ ...state, ...action.payload }),
 
     [fetchAllTypes.fulfilled]: (state, action) => {
       const typesWithPendingCategory = getTypesWithPendingCategory([
@@ -94,10 +90,16 @@ export const filterSlice = createSlice({
   },
 })
 
-export const { setFilters, openFilter, closeFilter } = filterSlice.actions
+export const { openFilter, closeFilter } = filterSlice.actions
+
+export const filtersChanged = (filters) => (dispatch) => {
+  dispatch(updateSelection(filters))
+  dispatch(fetchFilterCounts())
+  dispatch(fetchLocations())
+}
 
 export const selectionChanged = (types) => (dispatch) => {
-  dispatch(updateSelection(types))
+  dispatch(updateSelection({ types }))
   dispatch(fetchLocations())
 }
 

--- a/src/redux/selectParams.js
+++ b/src/redux/selectParams.js
@@ -25,12 +25,13 @@ const convertCenter = (center) => ({
 })
 
 export const selectParams = (state, extraParams = {}, isMap = true) => {
-  const { types, muni } = state.filter
+  const { types, muni, invasive } = state.filter
   const { view } = isMap ? state.map : state.list
 
   const params = {
     types: types && types.join(','),
     muni,
+    invasive,
     ...convertBounds(view.bounds),
     ...(!isMap && convertCenter(view.center)),
     ...extraParams,


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes:

- After clicking edit on an entry, the edit button stays around but doesn't do anything on click (not sure if this is intentional)
- After clicking settings and edit, a screen that says "Editing Location" shows up (not sure what is supposed to show up)
- Logging out on the accoutn page isn't reflected in the UI
- Can't log out of mobile. I tried clicking the logout button, but nothing would happen.
- No way to make a property private
- Seasonality dropdown is super small/difficult to use (looks like it's under a white pane)
- Edit button should not show if not logged in
- Unable to save a location after adding types. I clicked a location near me and tried adding some more types. It could not save and I got an error message. I was logged in.
- "Municipal" checkbox is not working
- "Invasive Species Only" button appears to have no function
- Also the icon of the self-location button turns into an X after clicking self-centering without giving access to location, and clicking on the X again will produce the same screen-zooming
- When clicking centering on self-location and access is not provided, clicking on the centering will just zoom in on the current screen(which I'm not sure if it's intended)

## Todos

- Convert forms on mobile to scrolling

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
